### PR TITLE
Avoid trailing commas' warning

### DIFF
--- a/lib/rsa_private_key.ex
+++ b/lib/rsa_private_key.ex
@@ -35,7 +35,7 @@ defmodule RsaEx.RSAPrivateKey do
       exponent_one: elem(rsa_key_seq, 7),
       exponent_two: elem(rsa_key_seq, 8),
       ctr_coefficient: elem(rsa_key_seq, 9),
-      other_prime_infos: elem(rsa_key_seq, 10),
+      other_prime_infos: elem(rsa_key_seq, 10)
     )
   end
 
@@ -53,7 +53,7 @@ defmodule RsaEx.RSAPrivateKey do
           rsa_private_key.exponent_one,
           rsa_private_key.exponent_two,
           rsa_private_key.ctr_coefficient,
-          rsa_private_key.other_prime_infos,
+          rsa_private_key.other_prime_infos
         }}
       _ ->
         {:error, "invalid RsaEx.RSAPrivateKey: #{inspect rsa_private_key}"}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RsaEx.Mixfile do
   def project do
     [app: :rsa_ex,
      version: "0.3.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.7",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),
@@ -18,7 +18,7 @@ defmodule RsaEx.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, ">= 0.0.0", only: :dev}]
+    [{:ex_doc, "~> 0.19", only: :dev}]
   end
 
   defp aliases do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
# Description

Avoid trailing commas' warning while compiling

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
Run `mix compile`
The warning `warning: trailing commas are not allowed inside function/macro call arguments
  lib/rsa_private_key.ex:38` is gone